### PR TITLE
feat(renderer): Add renderer to show the gones screen

### DIFF
--- a/cpu.go
+++ b/cpu.go
@@ -80,7 +80,7 @@ func (c *CPU) fetch() byte {
 }
 
 func (c *CPU) exec(inst *instruction) {
-	fmt.Printf("%#v, \n", inst)
+	//fmt.Printf("%#v, \n", inst)
 	switch inst.name {
 	case "JMP":
 		l, h := uint16(c.fetch()), uint16(c.fetch())
@@ -145,7 +145,7 @@ func (c *CPU) exec(inst *instruction) {
 	default:
 		fmt.Printf("unknown code:%#v\n", inst)
 	}
-	fmt.Printf("A:%#02x,X:%#02x,Y:%#02x,PC:%#04x\n", c.register.A, c.register.X, c.register.Y, c.register.PC)
+	//fmt.Printf("A:%#02x,X:%#02x,Y:%#02x,PC:%#04x\n", c.register.A, c.register.X, c.register.Y, c.register.PC)
 }
 
 // TODO:Bus導入
@@ -202,7 +202,7 @@ func (c *CPU) updateStatusRegister(result byte) {
 	} else {
 		c.register.P = clearBit(c.register.P, 7)
 	}
-	fmt.Printf("result=%#02x,Z=%v,N=%v\n", result, testBit(c.register.P, 1), testBit(c.register.P, 7))
+	//fmt.Printf("result=%#02x,Z=%v,N=%v\n", result, testBit(c.register.P, 1), testBit(c.register.P, 7))
 }
 
 func testBit(x, n byte) bool {

--- a/makefile
+++ b/makefile
@@ -1,6 +1,6 @@
 build:
 	go build -o bin/gones
 run :
-	go run main.go cpu.go ppu.go opecodes.go
+	go run main.go cpu.go ppu.go opecodes.go renderer.go
 test:
 	go test -v -run TestCPU_status

--- a/ppu.go
+++ b/ppu.go
@@ -1,5 +1,7 @@
 package main
 
+import "math/rand"
+
 type PPURegister struct {
 	// Control
 	CTRL   byte // 0x2000 割り込み
@@ -18,6 +20,12 @@ type PPURegister struct {
 type AddressRegister struct {
 	high, low        byte
 	lowShouldBeWrite bool
+}
+
+// Screen represents a screen to be displayed in a window.
+// Window here means the window of this application viewed directly by the user on the monitor.
+type Screen struct {
+	pixels []uint32
 }
 
 func (ar *AddressRegister) set(data uint16) {
@@ -91,4 +99,13 @@ func (p *PPU) writeData(data byte) {
 	addr := p.address.get()
 	p.memory[addr] = data
 	p.address.increment()
+}
+
+func (p *PPU) run(cycle int) *Screen {
+	pixels := make([]uint32, 800*600*4)
+	for i := range pixels {
+		pixels[i] = 0x00777777 + uint32(rand.Intn(0x00AAAAAA))
+	}
+
+	return &Screen{pixels}
 }

--- a/renderer.go
+++ b/renderer.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"github.com/veandco/go-sdl2/sdl"
+	"log"
+)
+
+type Renderer struct {
+	texture  *sdl.Texture
+	renderer *sdl.Renderer
+}
+
+func (r *Renderer) renderScreen(screen *Screen) {
+	// byte列から描画内容となるtextureを作成
+	// rect   : 更新する領域. nilの場合テクスチャ全体が対象.
+	// pixels : 生データ
+	// pitch  : ピクセルデータの水平方向バイト数. ライン間のパディング含む
+	if err := r.texture.UpdateRGBA(nil, screen.pixels, 800*4); err != nil {
+		log.Fatal(err)
+	}
+
+	// rendererを一度クリア
+	if err := r.renderer.Clear(); err != nil {
+		log.Fatal(err)
+	}
+	// 描画内容であるtextureを描画対象であるrendererにコピー
+	if err := r.renderer.Copy(r.texture, nil, nil); err != nil {
+		log.Fatal(err)
+	}
+	// 画面更新
+	r.renderer.Present()
+
+	sdl.Delay(20)
+}


### PR DESCRIPTION
Renderer構造体に画面表示に必要なリソースをまとめる。

Renderer.renderScreenで256x240の表示すべき画面のバイト列から実際のゲーム画面を描画する。
画面の描画にはgo-sdl2を利用する。
https://github.com/veandco/go-sdl2

