### PR TITLE
Add several implementations of CPU instructions to run nestest.nes

### DIFF
--- a/bus/bus.go
+++ b/bus/bus.go
@@ -45,6 +45,8 @@ func NewBus(rom *rom.Rom, ppu *ppu.PPU) *Bus {
 
 func (b *Bus) Read(address uint16) byte {
 	// 0x0000～0x07FF	0x0800	WRAM
+	// 0x0100～0x01FF   スタックポインタ
+
 	// 0x0800～0x0FFF	-	    WRAMのミラー1
 	// 0x1000～0x17FF	-	    WRAMのミラー2
 	// 0x1800～0x1FFF	-	    WRAMのミラー3

--- a/cpu/cpu_test.go
+++ b/cpu/cpu_test.go
@@ -76,6 +76,21 @@ func TestCPU_exec(t *testing.T) {
 			},
 		},
 		{
+			opecode: 0x24,
+			name:    "BIT", // TODO: 正しいか怪しい・・・
+			param:   []byte{0x01},
+			orgRegister: &Register{
+				PC: 0x8000,
+				A:  0b11111111,
+				P:  0b10100100,
+			},
+			wantRegister: &Register{
+				PC: 0x8001,
+				A:  0b1111_1111,
+				P:  0b00100110,
+			},
+		}, // 10100100
+		{
 			opecode:     0xA9,
 			name:        "LDA(set N)",
 			param:       []byte{0xFF},
@@ -352,6 +367,32 @@ func TestCPU_exec(t *testing.T) {
 		{
 			opecode: 0xF0,
 			name:    "BEQ_Relative_not_branch",
+			param:   []byte{0x10},
+			orgRegister: &Register{
+				P:  0b0000_0000,
+				PC: 0x8000,
+			},
+			wantRegister: &Register{
+				P:  0b0000_0000,
+				PC: 0x8001,
+			},
+		},
+		{
+			opecode: 0x70, // ステータスレジスタのVがセットされている場合アドレス「PC + IM8」へジャンプ",
+			name:    "BVS_Relative_branch",
+			param:   []byte{0x10},
+			orgRegister: &Register{
+				P:  0b0100_0000,
+				PC: 0x8000,
+			},
+			wantRegister: &Register{
+				P:  0b0100_0000,
+				PC: 0x8011,
+			},
+		},
+		{
+			opecode: 0x70, // ステータスレジスタのVがセットされている場合アドレス「PC + IM8」へジャンプ",
+			name:    "BVS_Relative_not_branch",
 			param:   []byte{0x10},
 			orgRegister: &Register{
 				P:  0b0000_0000,

--- a/cpu/cpu_test.go
+++ b/cpu/cpu_test.go
@@ -22,11 +22,35 @@ func TestCPU_exec(t *testing.T) {
 		wantData     byte
 	}{
 		{
+			opecode: 0x20,
+			name:    "JSR",
+			param:   []byte{0x10, 0x80},
+			orgRegister: &Register{
+				PC: 0x8000,
+			},
+			wantRegister: &Register{
+				PC: 0x8010,
+				S:  0x01,
+			},
+			address:  0x0100,
+			wantData: 0x80,
+		},
+		{
 			opecode:      0x4C,
 			name:         "JMP",
 			param:        []byte{0xFF, 0x80},
 			orgRegister:  &Register{PC: 0x8000},
 			wantRegister: &Register{PC: 0x80FF},
+		},
+		{
+			opecode:     0x38,
+			name:        "SEC",
+			param:       []byte{},
+			orgRegister: &Register{PC: 0x8000},
+			wantRegister: &Register{
+				PC: 0x8000,
+				P:  0b00000001,
+			},
 		},
 		{
 			opecode:     0x78,
@@ -105,6 +129,22 @@ func TestCPU_exec(t *testing.T) {
 			},
 			address:  0x0003,
 			wantData: 0xAA,
+		},
+		{
+			opecode: 0x86, // Xの内容をアドレス「MI8 | 0x00<<8 」に書き込む.
+			name:    "STX_ZeroPage",
+			param:   []byte{0x86},
+			orgRegister: &Register{
+				PC: 0x8000,
+				X:  0xFF,
+			},
+			wantRegister: &Register{
+				X:  0xFF,
+				PC: 0x8001,
+				P:  0b00000000, //N,Z: not affected
+			},
+			address:  0x0086,
+			wantData: 0xFF,
 		},
 		{
 			opecode: 0x9A, // XをSへコピー

--- a/cpu/cpu_test.go
+++ b/cpu/cpu_test.go
@@ -43,6 +43,19 @@ func TestCPU_exec(t *testing.T) {
 			wantRegister: &Register{PC: 0x80FF},
 		},
 		{
+			opecode: 0x18,
+			name:    "CLC",
+			param:   []byte{},
+			orgRegister: &Register{
+				PC: 0x8000,
+				P:  0b00000001,
+			},
+			wantRegister: &Register{
+				PC: 0x8000,
+				P:  0b00000000,
+			},
+		},
+		{
 			opecode:     0x38,
 			name:        "SEC",
 			param:       []byte{},
@@ -125,6 +138,22 @@ func TestCPU_exec(t *testing.T) {
 			wantRegister: &Register{
 				A:  0xAA,
 				PC: 0x8002,
+				P:  0b00000000, //N,Z: not affected
+			},
+			address:  0x0003,
+			wantData: 0xAA,
+		},
+		{
+			opecode: 0x85, // Aの内容をアドレス「MI8 | 0x00<<8 」に書き込む.
+			name:    "STA_ZeroPage",
+			param:   []byte{0x03},
+			orgRegister: &Register{
+				PC: 0x8000,
+				A:  0xAA,
+			},
+			wantRegister: &Register{
+				A:  0xAA,
+				PC: 0x8001,
 				P:  0b00000000, //N,Z: not affected
 			},
 			address:  0x0003,
@@ -252,6 +281,84 @@ func TestCPU_exec(t *testing.T) {
 			},
 			wantRegister: &Register{
 				P:  0b11111111,
+				PC: 0x8001,
+			},
+		},
+		{
+			opecode: 0xB0, // キャリーフラグがセットされている場合アドレス「PC + IM8」へ分岐
+			name:    "BCS_branch",
+			param:   []byte{0x10},
+			orgRegister: &Register{
+				P:  0b11111111,
+				PC: 0x8000,
+			},
+			wantRegister: &Register{
+				P:  0b11111111,
+				PC: 0x8011,
+			},
+		},
+		{
+			opecode: 0xB0, // キャリーフラグがセットされている場合アドレス「PC + IM8」へ分岐
+			name:    "BCS_not_branch",
+			param:   []byte{0x10},
+			orgRegister: &Register{
+				P:  0b00000000,
+				PC: 0x8000,
+			},
+			wantRegister: &Register{
+				P:  0b00000000,
+				PC: 0x8001,
+			},
+		},
+		{
+			opecode: 0x90, // キャリーフラグがクリアされている場合アドレス「PC + IM8」へ分岐
+			name:    "BCC_branch",
+			param:   []byte{0x10},
+			orgRegister: &Register{
+				P:  0b00000000,
+				PC: 0x8000,
+			},
+			wantRegister: &Register{
+				P:  0b00000000,
+				PC: 0x8011,
+			},
+		},
+		{
+			opecode: 0x90,
+			name:    "BCC_not_branch",
+			param:   []byte{0x10},
+			orgRegister: &Register{
+				P:  0b11111111,
+				PC: 0x8000,
+			},
+			wantRegister: &Register{
+				P:  0b11111111,
+				PC: 0x8001,
+			},
+		},
+		{
+			opecode: 0xF0, // ステータスレジスタのZがクリアされている場合アドレス「PC + IM8」へジャンプ",
+			name:    "BEQ_Relative_branch",
+			param:   []byte{0x10},
+			orgRegister: &Register{
+				P:  0b0000_0010,
+				PC: 0x8000,
+			},
+			wantRegister: &Register{
+				P:  0b0000_0010,
+				PC: 0x8011,
+			},
+		},
+		{
+			opecode: 0xF0,
+			name:    "BEQ_Relative_not_branch",
+			param:   []byte{0x10},
+			orgRegister: &Register{
+				P:  0b0000_0000,
+				PC: 0x8000,
+			},
+			wantRegister: &Register{
+				P:  0b0000_0000,
 				PC: 0x8001,
 			},
 		},

--- a/cpu/opecodes.go
+++ b/cpu/opecodes.go
@@ -12,6 +12,16 @@ var opecodes = map[byte]*instruction{
 		// N: not affected
 		// B: Set to 1
 	},
+	0x10: {
+		code:        0x10,
+		name:        "BPL", // Branch if Positive
+		mode:        "Relative",
+		description: "ステータスレジスタのNがクリアされている場合アドレス「PC + IM8」へジャンプ",
+		cycle:       2, // 2 (+1 if branch succeeds +2 if to a new page)
+		// Z: not affected
+		// N: not affected
+		// bytes:2
+	},
 	0x18: {
 		code:        0x18,
 		name:        "CLC", // Clear carry flag
@@ -33,6 +43,17 @@ var opecodes = map[byte]*instruction{
 		// N: not affected
 		// bytes:3
 	},
+	0x24: {
+		code:        0x24,
+		name:        "BIT", // Bit Test
+		mode:        "ZeroPage",
+		description: "Aと0x00IM8番地の値をビット比較演算します",
+		cycle:       3,
+		// Z: Set if the result if the AND is zero
+		// V: Set to bit 6 of the memory value
+		// N: Set to bit 7 of the memory value
+		// bytes:2
+	},
 	0x38: {
 		code:        0x38,
 		name:        "SEC",
@@ -51,6 +72,26 @@ var opecodes = map[byte]*instruction{
 		cycle:       3,
 		// Z: not affected
 		// N: not affected
+	},
+	0x50: {
+		code:        0x50,
+		name:        "BVC", // Branch if Overflow Clear
+		mode:        "Relative",
+		description: "ステータスレジスタのVがクリアされている場合アドレス「PC + IM8」へジャンプ",
+		cycle:       2, // 2 (+1 if branch succeeds +2 if to a new page)
+		// Z: not affected
+		// N: not affected
+		// bytes:2
+	},
+	0x70: {
+		code:        0x70,
+		name:        "BVS", // Branch if Overflow Set
+		mode:        "Relative",
+		description: "ステータスレジスタのVがセットされている場合アドレス「PC + IM8」へジャンプ",
+		cycle:       2, // 2 (+1 if branch succeeds +2 if to a new page)
+		// Z: not affected
+		// N: not affected
+		// bytes:2
 	},
 	0x78: {
 		code:  0x78,

--- a/cpu/opecodes.go
+++ b/cpu/opecodes.go
@@ -12,6 +12,26 @@ var opecodes = map[byte]*instruction{
 		// N: not affected
 		// B: Set to 1
 	},
+	0x20: {
+		code:        0x20,
+		name:        "JSR", // Jump to subroutine
+		mode:        "Absolute",
+		description: "サブルーチンを呼び出し",
+		cycle:       6,
+		// Z: not affected
+		// N: not affected
+		// bytes:3
+	},
+	0x38: {
+		code:        0x38,
+		name:        "SEC",
+		mode:        "Implied",
+		description: "Set carry flag",
+		cycle:       6,
+		// Z: not affected
+		// N: not affected
+		// bytes:1
+	},
 	0x4C: {
 		code:        0x4C,
 		name:        "JMP",
@@ -29,6 +49,16 @@ var opecodes = map[byte]*instruction{
 		// Z: not affected
 		// I: set to 1
 		// N: not affected
+	},
+	0x86: {
+		code:        0x86,
+		name:        "STX",
+		mode:        "ZeroPage", // 0x00を上位アドレス、PCに格納された値を下位アドレスとした番地を演算対象とする
+		description: "Stores the contents of the X register into memory",
+		cycle:       3,
+		// Z: not affected
+		// N: not affected
+		// bytes:2
 	},
 	0x8D: {
 		code:        0x8D,
@@ -75,6 +105,15 @@ var opecodes = map[byte]*instruction{
 		// Z:Set if A = 0
 		// N:Set if bit 7 of A is set
 	},
+	0xB0: {
+		code:        0xB0,
+		name:        "BCS", // Branch if Carry Set
+		mode:        "Relative",
+		description: "If the carry flag is set then add the relative displacement to the program counter to cause a branch to a new location",
+		cycle:       2,
+		// Z: not affected
+		// N: not affected
+	},
 	0xBD: {
 		code:        0xBD,
 		name:        "LDA",
@@ -102,6 +141,16 @@ var opecodes = map[byte]*instruction{
 		cycle:       2,
 		// Z:Set if X = 0
 		// N:Set if bit 7 of X is set
+	},
+	0xEA: {
+		code:        0xEA,
+		name:        "NOP",
+		mode:        "Implied",
+		description: "No operation",
+		cycle:       2,
+		// Z: not affected
+		// N: not affected
+		// Bytes:1
 	},
 	0x88: {
 		code:        0x88,

--- a/cpu/opecodes.go
+++ b/cpu/opecodes.go
@@ -12,6 +12,17 @@ var opecodes = map[byte]*instruction{
 		// N: not affected
 		// B: Set to 1
 	},
+	0x18: {
+		code:        0x18,
+		name:        "CLC", // Clear carry flag
+		mode:        "Implied",
+		description: "Set the carry flag to 0",
+		cycle:       2,
+		// Z: not affected
+		// N: not affected
+		// C: set to 0
+		// bytes:1
+	},
 	0x20: {
 		code:        0x20,
 		name:        "JSR", // Jump to subroutine
@@ -55,6 +66,26 @@ var opecodes = map[byte]*instruction{
 		name:        "STX",
 		mode:        "ZeroPage", // 0x00を上位アドレス、PCに格納された値を下位アドレスとした番地を演算対象とする
 		description: "Stores the contents of the X register into memory",
+		cycle:       3,
+		// Z: not affected
+		// N: not affected
+		// bytes:2
+	},
+	0x90: {
+		code:        0x90,
+		name:        "BCC", // Branch if Carry Clear
+		mode:        "Relative",
+		description: "If the carry flag is clear then add the relative displacement to the program counter to cause a branch to a new location.",
+		cycle:       2, // 2 (+1 if branch succeeds +2 if to a new page)
+		// Z: not affected
+		// N: not affected
+		// bytes:2
+	},
+	0x85: {
+		code:        0x85,
+		name:        "STA",
+		mode:        "ZeroPage",
+		description: "Aの内容をアドレス「MI8 | 0x00<<8 」に書き込む",
 		cycle:       3,
 		// Z: not affected
 		// N: not affected
@@ -165,10 +196,11 @@ var opecodes = map[byte]*instruction{
 		code:        0xF0,
 		name:        "BEQ",
 		mode:        "Relative",
-		description: "Branch on equal 0. ステータスレジスタのZがセットされている時に分岐.",
-		cycle:       3, // 4の場合もある
+		description: "Branch on equal 0. ステータスレジスタのZがセットされている場合アドレス「PC + IM8」へジャンプ",
+		cycle:       3, // 2 (+1 if branch succeeds +2 if to a new page)
 		// Z: not affected
 		// N: not affected
+		// bytes:2
 	},
 	0xF6: {
 		code:        0xF6,

--- a/util/util.go
+++ b/util/util.go
@@ -1,5 +1,6 @@
 package util
 
+// TestBit tests if the n bit of x is ON
 func TestBit(x, n byte) bool {
 	return x&(1<<n) != 0
 }


### PR DESCRIPTION
1byteずつnestest.nesを処理していき起動するまで足りてないCPU命令を追加していく


既知のログと比較して同じ実行結果になるように目指す。これをgolden fileとしたテストを作るのはアリかも
https://www.qmtpro.com/~nes/misc/nestest.log