### PR TITLE
Implements CPU instructions 2

### DIFF
--- a/cpu/cpu.go
+++ b/cpu/cpu.go
@@ -107,8 +107,18 @@ func (c *CPU) exec(inst *instruction) {
 		c.register.A = c.popByteFromStack()
 		c.updateStatusRegister(c.register.A)
 	case "AND":
-		c.register.A = c.register.A & c.fetch()
-		c.updateStatusRegister(c.register.A)
+		if inst.mode == "Immediate" {
+			c.register.A = c.register.A & c.fetch()
+			c.updateStatusRegister(c.register.A)
+		}
+	case "CMP":
+		if inst.mode == "Immediate" {
+			result := c.register.A - c.fetch()
+			if result >= 0 {
+				c.register.P = util.SetBit(c.register.P, 0)
+			}
+			c.updateStatusRegister(result)
+		}
 	case "RTS":
 		// スタックから戻り番地を取得しPCに格納する
 		c.register.PC = c.popAddressFromStack()

--- a/cpu/cpu.go
+++ b/cpu/cpu.go
@@ -106,6 +106,9 @@ func (c *CPU) exec(inst *instruction) {
 		// スタックからAにPull
 		c.register.A = c.popByteFromStack()
 		c.updateStatusRegister(c.register.A)
+	case "AND":
+		c.register.A = c.register.A & c.fetch()
+		c.updateStatusRegister(c.register.A)
 	case "RTS":
 		// スタックから戻り番地を取得しPCに格納する
 		c.register.PC = c.popAddressFromStack()

--- a/cpu/cpu.go
+++ b/cpu/cpu.go
@@ -106,6 +106,10 @@ func (c *CPU) exec(inst *instruction) {
 		c.register.P = util.SetBit(c.register.P, 0)
 	case "CLC":
 		c.register.P = util.ClearBit(c.register.P, 0)
+	case "SED":
+		// デシマルモードをON
+		// bit3を立てる
+		c.register.P = util.SetBit(c.register.P, 3)
 	case "SEI":
 		// IRQ割り込み禁止
 		// bit2を立てる

--- a/cpu/cpu.go
+++ b/cpu/cpu.go
@@ -97,13 +97,11 @@ func (c *CPU) exec(inst *instruction) {
 	case "JSR":
 		// 今のPCをスタックに退避し、PC=MI16にする
 		l, h := uint16(c.fetch()), uint16(c.fetch())
-		c.pushAddressToStack(c.register.PC - 1)
+		c.pushAddressToStack(c.register.PC)
 		c.register.PC = l | h<<8
 	case "RTS":
 		// スタックから戻り番地を取得しPCに格納する
-		l, h := uint16(c.fetch()), uint16(c.fetch())
-		c.pushAddressToStack(c.register.PC - 1)
-		c.register.PC = l | h<<8
+		c.register.PC = c.popAddressFromStack()
 	case "SEC":
 		c.register.P = util.SetBit(c.register.P, 0)
 	case "CLC":
@@ -275,4 +273,11 @@ func (c *CPU) pushAddressToStack(address uint16) {
 	c.write(0x0100+uint16(c.register.S), byte(h))
 	c.register.S++
 	c.write(0x0100+uint16(c.register.S), byte(l))
+}
+
+func (c *CPU) popAddressFromStack() uint16 {
+	l := uint16(c.read(0x0100 + uint16(c.register.S)))
+	c.register.S--
+	h := uint16(c.read(0x0100 + uint16(c.register.S))) // l|h<<8
+	return l | h<<8
 }

--- a/cpu/cpu.go
+++ b/cpu/cpu.go
@@ -102,6 +102,10 @@ func (c *CPU) exec(inst *instruction) {
 	case "PHP":
 		// ステータスのコピーをスタックに退避
 		c.pushByteToStack(c.register.P)
+	case "PLA":
+		// スタックからAにPull
+		c.register.A = c.popByteFromStack()
+		c.updateStatusRegister(c.register.A)
 	case "RTS":
 		// スタックから戻り番地を取得しPCに格納する
 		c.register.PC = c.popAddressFromStack()
@@ -292,4 +296,10 @@ func (c *CPU) popAddressFromStack() uint16 {
 	c.register.S--
 	h := uint16(c.read(0x0100 + uint16(c.register.S))) // l|h<<8
 	return l | h<<8
+}
+
+func (c *CPU) popByteFromStack() byte {
+	b := c.read(0x0100 + uint16(c.register.S-1))
+	c.register.S--
+	return b
 }

--- a/cpu/cpu.go
+++ b/cpu/cpu.go
@@ -15,8 +15,10 @@ type CPU struct {
 
 func NewCPU(bus *bus.Bus) *CPU {
 	cpu := &CPU{
-		register: &Register{},
-		bus:      bus,
+		register: &Register{
+			P: 0b0010_0000,
+		},
+		bus: bus,
 	}
 	return cpu
 }

--- a/cpu/cpu.go
+++ b/cpu/cpu.go
@@ -99,6 +99,9 @@ func (c *CPU) exec(inst *instruction) {
 		l, h := uint16(c.fetch()), uint16(c.fetch())
 		c.pushAddressToStack(c.register.PC)
 		c.register.PC = l | h<<8
+	case "PHP":
+		// ステータスのコピーをスタックに退避
+		c.pushByteToStack(c.register.P)
 	case "RTS":
 		// スタックから戻り番地を取得しPCに格納する
 		c.register.PC = c.popAddressFromStack()
@@ -270,6 +273,11 @@ func (c *CPU) updateStatusRegister(result byte) {
 		c.register.P = util.ClearBit(c.register.P, 7)
 	}
 	//fmt.Printf("result=%#02x,Z=%v,N=%v\n", result, testBit(c.register.P, 1), testBit(c.register.P, 7))
+}
+
+func (c *CPU) pushByteToStack(b byte) {
+	c.write(0x0100+uint16(c.register.S), b)
+	c.register.S++
 }
 
 func (c *CPU) pushAddressToStack(address uint16) {

--- a/cpu/cpu_test.go
+++ b/cpu/cpu_test.go
@@ -140,6 +140,20 @@ func TestCPU_exec(t *testing.T) {
 			},
 		},
 		{
+			opecode: 0xC9,
+			name:    "CMP",
+			param:   []byte{0x01},
+			orgRegister: &Register{
+				PC: 0x8000,
+				A:  0x01,
+			},
+			wantRegister: &Register{
+				PC: 0x8001,
+				A:  0x01,
+				P:  0b00000011,
+			},
+		},
+		{
 			opecode: 0x18,
 			name:    "CLC",
 			param:   []byte{},

--- a/cpu/cpu_test.go
+++ b/cpu/cpu_test.go
@@ -49,6 +49,22 @@ func TestCPU_memory(t *testing.T) {
 			address:  []uint16{0x0100, 0x0101},
 			wantData: []byte{0x80, 0x10},
 		},
+		{
+			opecode: 0x08,
+			name:    "PHP", // ステータスのコピーをスタックに退避
+			param:   []byte{},
+			init: func(cpu *CPU) {
+				cpu.register.PC = 0x8000
+				cpu.register.P = 0b0101_0101
+			},
+			wantRegister: &Register{
+				PC: 0x8000,
+				P:  0b0101_0101,
+				S:  0x01,
+			},
+			address:  []uint16{0x0100},
+			wantData: []byte{0b0101_0101},
+		},
 	} {
 		tt := tt
 		t.Run(fmt.Sprintf("code=%#02x:%s", tt.opecode, tt.name), func(t *testing.T) {

--- a/cpu/cpu_test.go
+++ b/cpu/cpu_test.go
@@ -115,6 +115,16 @@ func TestCPU_exec(t *testing.T) {
 			},
 		},
 		{
+			opecode:     0xF8,
+			name:        "SED",
+			param:       []byte{},
+			orgRegister: &Register{PC: 0x8000},
+			wantRegister: &Register{
+				PC: 0x8000,
+				P:  0b00001000,
+			},
+		},
+		{
 			opecode:     0x78,
 			name:        "SEI",
 			param:       []byte{},

--- a/cpu/cpu_test.go
+++ b/cpu/cpu_test.go
@@ -65,6 +65,24 @@ func TestCPU_memory(t *testing.T) {
 			address:  []uint16{0x0100},
 			wantData: []byte{0b0101_0101},
 		},
+		{
+			opecode: 0x68,
+			name:    "PLA", // スタックからAにpull
+			param:   []byte{},
+			init: func(cpu *CPU) {
+				cpu.register.PC = 0x8000
+				cpu.register.A = 0xFF
+				cpu.register.S = 0x10
+				cpu.pushByteToStack(0x20)
+			},
+			wantRegister: &Register{
+				PC: 0x8000,
+				A:  0x20,
+				S:  0x10,
+			},
+			address:  []uint16{0x0110},
+			wantData: []byte{0x20},
+		},
 	} {
 		tt := tt
 		t.Run(fmt.Sprintf("code=%#02x:%s", tt.opecode, tt.name), func(t *testing.T) {

--- a/cpu/cpu_test.go
+++ b/cpu/cpu_test.go
@@ -126,6 +126,20 @@ func TestCPU_exec(t *testing.T) {
 			wantRegister: &Register{PC: 0x80FF},
 		},
 		{
+			opecode: 0x29,
+			name:    "AND",
+			param:   []byte{0b1111_0000},
+			orgRegister: &Register{
+				PC: 0x8000,
+				A:  0xFF,
+			},
+			wantRegister: &Register{
+				PC: 0x8001,
+				A:  0b1111_0000,
+				P:  0b10000000,
+			},
+		},
+		{
 			opecode: 0x18,
 			name:    "CLC",
 			param:   []byte{},

--- a/cpu/cpu_test.go
+++ b/cpu/cpu_test.go
@@ -27,6 +27,7 @@ func TestCPU_memory(t *testing.T) {
 			param:   []byte{0x10, 0x80},
 			init: func(cpu *CPU) {
 				cpu.register.PC = 0x8000
+				cpu.register.P = 0b0000_0000
 			},
 			wantRegister: &Register{
 				PC: 0x8010,
@@ -41,6 +42,7 @@ func TestCPU_memory(t *testing.T) {
 			param:   []byte{},
 			init: func(cpu *CPU) {
 				cpu.register.PC = 0x8100
+				cpu.register.P = 0b0000_0000
 				cpu.pushAddressToStack(0x8010)
 			},
 			wantRegister: &Register{
@@ -72,6 +74,7 @@ func TestCPU_memory(t *testing.T) {
 			init: func(cpu *CPU) {
 				cpu.register.PC = 0x8000
 				cpu.register.A = 0xFF
+				cpu.register.P = 0b0000_0000
 				cpu.register.S = 0x10
 				cpu.pushByteToStack(0x20)
 			},
@@ -473,7 +476,7 @@ func TestCPU_exec(t *testing.T) {
 			},
 		},
 		{
-			opecode: 0xF0, // ステータスレジスタのZがクリアされている場合アドレス「PC + IM8」へジャンプ",
+			opecode: 0xF0, // ステータスレジスタのZがセットされている場合アドレス「PC + IM8」へジャンプ",
 			name:    "BEQ_Relative_branch",
 			param:   []byte{0x10},
 			orgRegister: &Register{

--- a/cpu/opecodes.go
+++ b/cpu/opecodes.go
@@ -262,4 +262,15 @@ var opecodes = map[byte]*instruction{
 		// Z:Set if result = 0
 		// N:Set if bit 7 of result is set
 	},
+	0xF8: {
+		code:        0xF8, // Set Decimal Flag
+		name:        "SED",
+		mode:        "Implied",
+		description: "Set the decimal mode flag to one.",
+		cycle:       2,
+		// Z: not affected
+		// N: not affected
+		// D: Set to 1
+		// bytes:1
+	},
 }

--- a/cpu/opecodes.go
+++ b/cpu/opecodes.go
@@ -12,6 +12,16 @@ var opecodes = map[byte]*instruction{
 		// N: not affected
 		// B: Set to 1
 	},
+	0x08: {
+		code:        0x08,
+		name:        "PHP", // Push Processor Status
+		mode:        "Implied",
+		description: "Pushes a copy of the status flags on to the stack.",
+		cycle:       3,
+		// Z: not affected
+		// N: not affected
+		// bytes:1
+	},
 	0x10: {
 		code:        0x10,
 		name:        "BPL", // Branch if Positive

--- a/cpu/opecodes.go
+++ b/cpu/opecodes.go
@@ -73,6 +73,17 @@ var opecodes = map[byte]*instruction{
 		// N: Set if bit 7 set
 		// bytes:2
 	},
+	0xC9: {
+		code:        0xC9,
+		name:        "CMP", // Compare
+		mode:        "Immediate",
+		description: "This instruction compares the contents of the accumulator with another memory held value and sets the zero and carry flags as appropriate.",
+		cycle:       2,
+		// C: Set if A >= M
+		// Z: Set if A = M
+		// N: Set if bit 7 of the result is set
+		// bytes:2
+	},
 	0x60: {
 		code:        0x60,
 		name:        "RTS", // Return from Subroutine

--- a/cpu/opecodes.go
+++ b/cpu/opecodes.go
@@ -63,6 +63,16 @@ var opecodes = map[byte]*instruction{
 		// N: not affected
 		// bytes:3
 	},
+	0x29: {
+		code:        0x29,
+		name:        "AND", // Logical AND
+		mode:        "Immediate",
+		description: "A logical AND is performed, bit by bit, on the accumulator contents using the contents of a byte of memory.",
+		cycle:       2,
+		// Z: Set if A = 0
+		// N: Set if bit 7 set
+		// bytes:2
+	},
 	0x60: {
 		code:        0x60,
 		name:        "RTS", // Return from Subroutine

--- a/cpu/opecodes.go
+++ b/cpu/opecodes.go
@@ -43,6 +43,16 @@ var opecodes = map[byte]*instruction{
 		// N: not affected
 		// bytes:3
 	},
+	0x60: {
+		code:        0x60,
+		name:        "RTS", // Return from Subroutine
+		mode:        "Implied",
+		description: "サブルーチンから復帰",
+		cycle:       6,
+		// Z: not affected
+		// N: not affected
+		// bytes:1
+	},
 	0x24: {
 		code:        0x24,
 		name:        "BIT", // Bit Test

--- a/cpu/opecodes.go
+++ b/cpu/opecodes.go
@@ -22,6 +22,16 @@ var opecodes = map[byte]*instruction{
 		// N: not affected
 		// bytes:1
 	},
+	0x68: {
+		code:        0x68,
+		name:        "PLA", // Pull Accumulator
+		mode:        "Implied",
+		description: "Pulls an 8 bit value from the stack and into the accumulator. The zero and negative flags are set as appropriate.",
+		cycle:       4,
+		// Z: Set if A = 0
+		// N: Set if bit 7 of A is set
+		// bytes:1
+	},
 	0x10: {
 		code:        0x10,
 		name:        "BPL", // Branch if Positive

--- a/main.go
+++ b/main.go
@@ -26,6 +26,7 @@ func main() {
 }
 
 func run(cpu *cpu.CPU, ppu *ppu.PPU, joyPad *joypad.Joypad) {
+	cpu.Reset()
 	for {
 		cycle := cpu.Run()
 		if screen := ppu.Run(cycle * 3); screen != nil {


### PR DESCRIPTION
Continue to https://github.com/yusukemisa/gones/pull/12


こちらのログのこの辺りまで実行するのに必要な命令を追加する
https://www.qmtpro.com/~nes/misc/nestest.log
```
C7E5  78        SEI                             A:00 X:00 Y:00 P:67 SP:FB PPU:  1,202 CYC:181
C7E6  F8        SED                             A:00 X:00 Y:00 P:67 SP:FB PPU:  1,208 CYC:183
C7E7  08        PHP                             A:00 X:00 Y:00 P:6F SP:FB PPU:  1,214 CYC:185
C7E8  68        PLA                             A:00 X:00 Y:00 P:6F SP:FA PPU:  1,223 CYC:188
C7E9  29 EF     AND #$EF                        A:7F X:00 Y:00 P:6D SP:FB PPU:  1,235 CYC:192
C7EB  C9 6F     CMP #$6F                        A:6F X:00 Y:00 P:6D SP:FB PPU:  1,241 CYC:194
```


今のところここまで実行できている
```
C7DE, &cpu.instruction{code:0x85, name:"STA", mode:"ZeroPage", description:"Aの内容をアドレス「MI8 | 0x00<<8 」に書き込む", cycle:3},
C7E0, &cpu.instruction{code:0x24, name:"BIT", mode:"ZeroPage", description:"Aと0x00IM8番地の値をビット比較演算します", cycle:3},
C7E2, &cpu.instruction{code:0xa9, name:"LDA", mode:"Immediate", description:"次アドレスの即値をAにロード", cycle:2},
C7E4, &cpu.instruction{code:0x38, name:"SEC", mode:"Implied", description:"Set carry flag", cycle:6},
C7E5, &cpu.instruction{code:0x78, name:"SEI", mode:"Implied", description:"", cycle:2},
2023/01/25 00:13:25 opecode not found:0xf8

```


## CMPまで実装後
want
```
C7EB  C9 6F     CMP #$6F                        A:6F X:00 Y:00 P:6D SP:FB PPU:  1,241 CYC:194
C7ED  F0 04     BEQ $C7F3                       A:6F X:00 Y:00 P:6F SP:FB PPU:  1,247 CYC:196
C7F3  EA        NOP                             A:6F X:00 Y:00 P:6F SP:FB PPU:  1,256 CYC:199
C7F4  A9 40     LDA #$40                        A:6F X:00 Y:00 P:6F SP:FB PPU:  1,262 CYC:201
C7F6  85 01     STA $01 = FF                    A:40 X:00 Y:00 P:6D SP:FB PPU:  1,268 CYC:203
C7F8  24 01     BIT $01 = 40                    A:40 X:00 Y:00 P:6D SP:FB PPU:  1,277 CYC:206
```

got: BEQの処理が正しくなさそう・・
```
C7EB, &cpu.instruction{code:0xc9, name:"CMP", mode:"Immediate", description:"This instruction compares the contents of the accumulator with another memory held value and sets the zero and carry flags as appropriate.", cycle:2},
C7ED, &cpu.instruction{code:0xf0, name:"BEQ", mode:"Relative", description:"Branch on equal 0. ステータスレジスタのZがセットされている場合アドレス「PC + IM8」へジャンプ", cycle:3},
C7EF, &cpu.instruction{code:0xa2, name:"LDX", mode:"Immediate", description:"次アドレスの即値をXにロード", cycle:2},
C7F1, &cpu.instruction{code:0x86, name:"STX", mode:"ZeroPage", description:"Stores the contents of the X register into memory", cycle:3},
C7F3, &cpu.instruction{code:0xea, name:"NOP", mode:"Implied", description:"No operation", cycle:2},
C7F4, &cpu.instruction{code:0xa9, name:"LDA", mode:"Immediate", description:"次アドレスの即値をAにロード", cycle:2},
C7F6, &cpu.instruction{code:0x85, name:"STA", mode:"ZeroPage", description:"Aの内容をアドレス「MI8 | 0x00<<8 」に書き込む", cycle:3},
C7F8, &cpu.instruction{code:0x24, name:"BIT", mode:"ZeroPage", description:"Aと0x00IM8番地の値をビット比較演算します", cycle:3},

```

ステータスレジスタの初期値を0b0010_0000にすると解決した -> なぜなのか

