### PR TITLE
Implements CPU instructions 3

### DIFF
--- a/cpu/cpu.go
+++ b/cpu/cpu.go
@@ -128,6 +128,10 @@ func (c *CPU) exec(inst *instruction) {
 		c.register.P = util.SetBit(c.register.P, 0)
 	case "CLC":
 		c.register.P = util.ClearBit(c.register.P, 0)
+	case "CLD":
+		// デシマルモードをOFF
+		// bit3を消す
+		c.register.P = util.ClearBit(c.register.P, 3)
 	case "SED":
 		// デシマルモードをON
 		// bit3を立てる

--- a/cpu/cpu.go
+++ b/cpu/cpu.go
@@ -104,6 +104,9 @@ func (c *CPU) exec(inst *instruction) {
 	case "PHP":
 		// ステータスのコピーをスタックに退避
 		c.pushByteToStack(c.register.P)
+	case "PHA":
+		// アキュムレーターのコピーをスタックに退避
+		c.pushByteToStack(c.register.A)
 	case "PLA":
 		// スタックからAにPull
 		c.register.A = c.popByteFromStack()

--- a/cpu/cpu.go
+++ b/cpu/cpu.go
@@ -247,6 +247,14 @@ func (c *CPU) exec(inst *instruction) {
 				c.register.PC = uint16(addr)
 			}
 		}
+	case "BMI":
+		if inst.mode == "Relative" {
+			relAddr := int8(c.fetch())
+			if util.TestBit(c.register.P, 7) {
+				addr := int(relAddr) + int(c.register.PC)
+				c.register.PC = uint16(addr)
+			}
+		}
 	case "BNE":
 		if inst.mode == "Relative" {
 			// 分岐するしないに関係なくPCが2byte回る必要ある

--- a/cpu/cpu.go
+++ b/cpu/cpu.go
@@ -111,6 +111,9 @@ func (c *CPU) exec(inst *instruction) {
 		// スタックからAにPull
 		c.register.A = c.popByteFromStack()
 		c.updateStatusRegister(c.register.A)
+	case "PLP":
+		// スタックからPにPull
+		c.register.P = c.popByteFromStack()
 	case "AND":
 		if inst.mode == "Immediate" {
 			c.register.A = c.register.A & c.fetch()

--- a/cpu/cpu_test.go
+++ b/cpu/cpu_test.go
@@ -575,6 +575,32 @@ func TestCPU_exec(t *testing.T) {
 				PC: 0x8001,
 			},
 		},
+		{
+			opecode: 0x30, // Branch if Minus
+			name:    "BMI_branch",
+			param:   []byte{0x10},
+			orgRegister: &Register{
+				P:  0b1000_0000,
+				PC: 0x8000,
+			},
+			wantRegister: &Register{
+				P:  0b1000_0000,
+				PC: 0x8011,
+			},
+		},
+		{
+			opecode: 0x10, // Branch if Positive
+			name:    "BPL_branch",
+			param:   []byte{0x10},
+			orgRegister: &Register{
+				P:  0b0000_0000,
+				PC: 0x8000,
+			},
+			wantRegister: &Register{
+				P:  0b0000_0000,
+				PC: 0x8011,
+			},
+		},
 	} {
 		tt := tt
 		t.Run(fmt.Sprintf("code=%#02x:%s", tt.opecode, tt.name), func(t *testing.T) {

--- a/cpu/cpu_test.go
+++ b/cpu/cpu_test.go
@@ -180,6 +180,19 @@ func TestCPU_exec(t *testing.T) {
 			},
 		},
 		{
+			opecode: 0xD8,
+			name:    "CLD",
+			param:   []byte{},
+			orgRegister: &Register{
+				PC: 0x8000,
+				P:  0b00001000,
+			},
+			wantRegister: &Register{
+				PC: 0x8000,
+				P:  0b00000000,
+			},
+		},
+		{
 			opecode:     0xF8,
 			name:        "SED",
 			param:       []byte{},

--- a/cpu/cpu_test.go
+++ b/cpu/cpu_test.go
@@ -31,7 +31,7 @@ func TestCPU_memory(t *testing.T) {
 			},
 			wantRegister: &Register{
 				PC: 0x8010,
-				S:  0x01,
+				S:  0x02,
 			},
 			address:  []uint16{0x0100, 0x0101},
 			wantData: []byte{0x80, 0x02},

--- a/cpu/cpu_test.go
+++ b/cpu/cpu_test.go
@@ -103,6 +103,24 @@ func TestCPU_memory(t *testing.T) {
 			address:  []uint16{0x0110},
 			wantData: []byte{0x20},
 		},
+		{
+			opecode: 0x28,
+			name:    "PLP", // スタックからPにpull
+			param:   []byte{},
+			init: func(cpu *CPU) {
+				cpu.register.PC = 0x8000
+				cpu.register.P = 0b0000_0000
+				cpu.register.S = 0x10
+				cpu.pushByteToStack(0b1111_0000)
+			},
+			wantRegister: &Register{
+				PC: 0x8000,
+				P:  0b1111_0000,
+				S:  0x10,
+			},
+			address:  []uint16{0x0110},
+			wantData: []byte{0b1111_0000},
+		},
 	} {
 		tt := tt
 		t.Run(fmt.Sprintf("code=%#02x:%s", tt.opecode, tt.name), func(t *testing.T) {

--- a/cpu/cpu_test.go
+++ b/cpu/cpu_test.go
@@ -68,6 +68,23 @@ func TestCPU_memory(t *testing.T) {
 			wantData: []byte{0b0101_0101},
 		},
 		{
+			opecode: 0x48,
+			name:    "PHA", // アキュムレーターのコピーをスタックに退避
+			param:   []byte{},
+			init: func(cpu *CPU) {
+				cpu.register.PC = 0x8000
+				cpu.register.A = 0x10
+				cpu.register.P = 0b0000_0000
+			},
+			wantRegister: &Register{
+				PC: 0x8000,
+				A:  0x10,
+				S:  0x01,
+			},
+			address:  []uint16{0x0100},
+			wantData: []byte{0x10},
+		},
+		{
 			opecode: 0x68,
 			name:    "PLA", // スタックからAにpull
 			param:   []byte{},

--- a/cpu/opecodes.go
+++ b/cpu/opecodes.go
@@ -58,16 +58,6 @@ var opecodes = map[byte]*instruction{
 		// N: Set if bit 7 of A is set
 		// bytes:1
 	},
-	0x10: {
-		code:        0x10,
-		name:        "BPL", // Branch if Positive
-		mode:        "Relative",
-		description: "ステータスレジスタのNがクリアされている場合アドレス「PC + IM8」へジャンプ",
-		cycle:       2, // 2 (+1 if branch succeeds +2 if to a new page)
-		// Z: not affected
-		// N: not affected
-		// bytes:2
-	},
 	0x18: {
 		code:        0x18,
 		name:        "CLC", // Clear carry flag
@@ -149,6 +139,26 @@ var opecodes = map[byte]*instruction{
 		cycle:       3,
 		// Z: not affected
 		// N: not affected
+	},
+	0x10: {
+		code:        0x10,
+		name:        "BPL", // Branch if Positive
+		mode:        "Relative",
+		description: "ステータスレジスタのNがクリアされている場合アドレス「PC + IM8」へジャンプ",
+		cycle:       2, // 2 (+1 if branch succeeds +2 if to a new page)
+		// Z: not affected
+		// N: not affected
+		// bytes:2
+	},
+	0x30: {
+		code:        0x30,
+		name:        "BMI", // Branch if Minus
+		mode:        "Relative",
+		description: "ステータスレジスタのNがセットされている場合アドレス「PC + IM8」へジャンプ",
+		cycle:       2, // 2 (+1 if branch succeeds +2 if to a new page)
+		// Z: not affected
+		// N: not affected
+		// bytes:2
 	},
 	0x50: {
 		code:        0x50,

--- a/cpu/opecodes.go
+++ b/cpu/opecodes.go
@@ -22,6 +22,22 @@ var opecodes = map[byte]*instruction{
 		// N: not affected
 		// bytes:1
 	},
+	0x28: {
+		code: 0x28,
+		name: "PLP", // Pull Processor Status
+		mode: "Implied",
+		description: "Pulls an 8 bit value from the stack and into the processor flags. " +
+			"The flags will take on new states as determined by the value pulled.",
+		cycle: 4,
+		// C: Set from stack
+		// Z: Set from stack
+		// I: Set from stack
+		// D: Set from stack
+		// B: Set from stack
+		// V: Set from stack
+		// N: Set from stack
+		// bytes:1
+	},
 	0x48: {
 		code:        0x48,
 		name:        "PHA", // Push Accumulator

--- a/cpu/opecodes.go
+++ b/cpu/opecodes.go
@@ -303,6 +303,17 @@ var opecodes = map[byte]*instruction{
 		// Z:Set if result = 0
 		// N:Set if bit 7 of result is set
 	},
+	0xD8: {
+		code:        0xF8, // Clear Decimal Flag
+		name:        "CLD",
+		mode:        "Implied",
+		description: "Set the decimal mode flag to 0.",
+		cycle:       2,
+		// Z: not affected
+		// N: not affected
+		// D: Set to 0
+		// bytes:1
+	},
 	0xF8: {
 		code:        0xF8, // Set Decimal Flag
 		name:        "SED",

--- a/cpu/opecodes.go
+++ b/cpu/opecodes.go
@@ -22,6 +22,16 @@ var opecodes = map[byte]*instruction{
 		// N: not affected
 		// bytes:1
 	},
+	0x48: {
+		code:        0x48,
+		name:        "PHA", // Push Accumulator
+		mode:        "Implied",
+		description: "Pushes a copy of the accumulator on to the stack.",
+		cycle:       3,
+		// Z: not affected
+		// N: not affected
+		// bytes:1
+	},
 	0x68: {
 		code:        0x68,
 		name:        "PLA", // Pull Accumulator


### PR DESCRIPTION
Continue to https://github.com/yusukemisa/gones/pull/13

こちらのログのこの辺りまで実行するのに必要な命令を追加する
https://www.qmtpro.com/~nes/misc/nestest.log

```
C81B  F0 04     BEQ $C821                       A:2F X:00 Y:00 P:2F SP:FB PPU:  2, 86 CYC:256
C821  EA        NOP                             A:2F X:00 Y:00 P:2F SP:FB PPU:  2, 95 CYC:259
C822  A9 FF     LDA #$FF                        A:2F X:00 Y:00 P:2F SP:FB PPU:  2,101 CYC:261
C824  48        PHA                             A:FF X:00 Y:00 P:AD SP:FB PPU:  2,107 CYC:263
C825  28        PLP                             A:FF X:00 Y:00 P:AD SP:FA PPU:  2,116 CYC:266
C826  D0 09     BNE $C831                       A:FF X:00 Y:00 P:EF SP:FB PPU:  2,128 CYC:270
C828  10 07     BPL $C831                       A:FF X:00 Y:00 P:EF SP:FB PPU:  2,134 CYC:272
C82A  50 05     BVC $C831                       A:FF X:00 Y:00 P:EF SP:FB PPU:  2,140 CYC:274
C82C  90 03     BCC $C831                       A:FF X:00 Y:00 P:EF SP:FB PPU:  2,146 CYC:276
```


この辺りまで実装。関数の呼び出しと呼び出しポイントへの復帰にバグがあったので修正
```
C884, &cpu.instruction{code:0x60, name:"RTS", mode:"Implied", description:"サブルーチンから復帰", cycle:6},
C603, &cpu.instruction{code:0x20, name:"JSR", mode:"Absolute", description:"サブルーチンを呼び出し", cycle:6},
C885, &cpu.instruction{code:0xea, name:"NOP", mode:"Implied", description:"No operation", cycle:2},
C886, &cpu.instruction{code:0x18, name:"CLC", mode:"Implied", description:"Set the carry flag to 0", cycle:2},
C887, &cpu.instruction{code:0xa9, name:"LDA", mode:"Immediate", description:"次アドレスの即値をAにロード", cycle:2},
C889, &cpu.instruction{code:0x85, name:"STA", mode:"ZeroPage", description:"Aの内容をアドレス「MI8 | 0x00<<8 」に書き込む", cycle:3},
C88B, &cpu.instruction{code:0x24, name:"BIT", mode:"ZeroPage", description:"Aと0x00IM8番地の値をビット比較演算します", cycle:3},
C88D, &cpu.instruction{code:0xa9, name:"LDA", mode:"Immediate", description:"次アドレスの即値をAにロード", cycle:2},
2023/01/27 00:26:00 opecode not found:0x09

```